### PR TITLE
Disable turnstile autorefresh

### DIFF
--- a/src/frontend/views/isbn-registry/forms/IsbnIsmnPublicationRegistrationForm.jsx
+++ b/src/frontend/views/isbn-registry/forms/IsbnIsmnPublicationRegistrationForm.jsx
@@ -122,7 +122,9 @@ function IsbnIsmnPublicationRegistrationForm (props) {
 
     const turnstileWidgedId = window.turnstile.render('#turnstileWidget', {
       sitekey: siteKey,
-      callback: (token) => makeApiCall(token)
+      callback: (token) => makeApiCall(token),
+      'error-callback': () => {loading = false;},
+      'refresh-expired': 'never'
     });
 
     setTurnstileId(turnstileWidgedId);

--- a/src/frontend/views/isbn-registry/forms/PublisherRegistrationForm.jsx
+++ b/src/frontend/views/isbn-registry/forms/PublisherRegistrationForm.jsx
@@ -129,7 +129,8 @@ function PublisherRegistrationForm (props) {
     const turnstileWidgedId = window.turnstile.render('#turnstileWidget', {
       sitekey: siteKey,
       callback: (token) => makeApiCall(token),
-      ['error-callback']: () => {loading = false;}
+      'error-callback': () => {loading = false;},
+      'refresh-expired': 'never'
     });
 
     setTurnstileId(turnstileWidgedId);

--- a/src/frontend/views/isbn-registry/identifierBatch/IdentifierBatch.jsx
+++ b/src/frontend/views/isbn-registry/identifierBatch/IdentifierBatch.jsx
@@ -54,6 +54,11 @@ function IdentifierBatch ({configuration, match}) {
 
   // Turnstile
   const [turnstileId, setTurnstileId] = useState(null);
+  const turnstileConfiguration = {
+    sitekey: siteKey,
+    callback: (token) => makeApiCall(token),
+    'refresh-expired': 'never'
+  };
 
   // Fetch the batch data
   const {data, loading, error} = useItem({
@@ -63,6 +68,11 @@ function IdentifierBatch ({configuration, match}) {
     prefetch: true,
     fetchOnce: true
   });
+
+  // Turnstile callback api function
+  async function makeApiCall(turnstileToken) {
+    await downloadIdentifierBatch(id, turnstileToken);
+  }
 
   // Turnstile
   async function handleBatchDownload() {
@@ -74,29 +84,18 @@ function IdentifierBatch ({configuration, match}) {
       if(turnstileId) {
         window.turnstile.reset(turnstileId);
       } else {
-        const turnstileWidgedId = window.turnstile.render('#turnstileWidget', {
-          sitekey: siteKey,
-          callback: (token) => makeApiCall(token)
-        });
-
+        const turnstileWidgedId = window.turnstile.render('#turnstileWidget', turnstileConfiguration);
         setTurnstileId(turnstileWidgedId);
       }
     } catch(err) {
       // Attempt reinitializing widget once more
-      const turnstileWidgedId = window.turnstile.render('#turnstileWidget', {
-        sitekey: siteKey,
-        callback: (token) => makeApiCall(token)
-      });
+      const turnstileWidgedId = window.turnstile.render('#turnstileWidget', turnstileConfiguration);
 
       setTurnstileId(turnstileWidgedId);
     }
 
     // For disabling buttons set minimum resolve time to 3 seconds
     return await new Promise(r => setTimeout(r, 3000));
-
-    async function makeApiCall(turnstileToken) {
-      await downloadIdentifierBatch(id, turnstileToken);
-    }
   }
 
   // Get the component based on state

--- a/src/frontend/views/issn-registry/forms/IssnPublicationRegistrationForm.jsx
+++ b/src/frontend/views/issn-registry/forms/IssnPublicationRegistrationForm.jsx
@@ -116,7 +116,9 @@ function IssnPublicationRegistrationForm (props) {
 
     const turnstileWidgedId = window.turnstile.render('#turnstileWidget', {
       sitekey: siteKey,
-      callback: (token) => makeApiCall(token)
+      callback: (token) => makeApiCall(token),
+      'error-callback': () => {loading = false;},
+      'refresh-expired': 'never'
     });
 
     setTurnstileId(turnstileWidgedId);


### PR DESCRIPTION
- Disabled turnstile autorefresh so that callback functions do not invoke after autorefresh in case user has the tab open for longer period of time than the token is valid.