### PR TITLE
fix validation of classification field in publisher registration form

### DIFF
--- a/src/frontend/components/form/publisherRegistrationForm/validation.js
+++ b/src/frontend/components/form/publisherRegistrationForm/validation.js
@@ -107,6 +107,11 @@ export function validate(values) {
       classificationErrors.classificationOther = 'field.required';
     }
 
+    // Max. amount of classification keywords is 5
+    if (values.classification?.length > 5) {
+      classificationErrors.classification = 'classification.maxAmount';
+    }
+
     return classificationErrors;
   }
 }

--- a/src/frontend/intl/en.js
+++ b/src/frontend/intl/en.js
@@ -206,6 +206,7 @@ const en = {
   'error.identifierBatch.invalid': 'Loading of identifier batch failed. Please try again or contact customer service',
   'error.formEdit': 'There are errors in the form, please check the fields marked in red: ',
   'error.emptyField': ' ',
+  'error.classification.maxAmount': 'You can add max. 5 classification keywords',
 
   // Error page texts
   'errorPage.header': 'Sorry, something went wrong',

--- a/src/frontend/intl/fi.js
+++ b/src/frontend/intl/fi.js
@@ -206,6 +206,7 @@ const fi = {
   'error.identifierBatch.invalid': 'Tunnuslistan hakeminen epäonnistui. Yrittäkää uudelleen tai ottakaa tarvittaessa yhteyttä asiakaspalveluun',
   'error.formEdit': 'Lomakkeessa on virheellisiä tietoja. Tarkistakaa seuraavat kentät:',
   'error.emptyField': ' ',
+  'error.classification.maxAmount': 'Voit lisätä enintään 5 aihealuetta',
 
   // Error page texts
   'errorPage.header': 'Olemme pahoillamme, mutta jokin meni väärin',

--- a/src/frontend/intl/sv.js
+++ b/src/frontend/intl/sv.js
@@ -206,6 +206,7 @@ const sv = {
   'error.identifierBatch.invalid': 'Laddningen av identifikatorerna misslyckades. Vänligen försök på nytt eller ta kontakt med vår kundservice.',
   'error.formEdit': 'En del av uppgifterna är fel, vänligen korrigera fälten som är markerade med rött:',
   'error.emptyField': ' ',
+  'error.classification.maxAmount': 'Du har lagt till det maximala antalet ämnesord (5 st)',
 
   // Error page texts
   'errorPage.header': 'Något gick tyvärr fel',


### PR DESCRIPTION
Fixed validation of classification keywords field in publisher registration form - max. 5 keywords is allowed