### PR TITLE
fix order of info boxes on preview page of the dissertation form

### DIFF
--- a/src/frontend/components/form/isbnIsmnRegistrationForm/Preview.jsx
+++ b/src/frontend/components/form/isbnIsmnRegistrationForm/Preview.jsx
@@ -37,6 +37,8 @@ import AuthorCard from '/src/frontend/components/subComponents/AuthorCard.jsx';
 import {PUBLICATION_TYPES, PUBLISHING_ACTIVITIES_TYPE} from '../constants';
 
 function Preview ({values, intl}) {
+  const isDissertation = values.publicationType === PUBLICATION_TYPES.DISSERTATION;
+
   return (
     <>
       <div className="mainContainer">
@@ -45,13 +47,13 @@ function Preview ({values, intl}) {
           <Typography variant="h3" className="listComponentContainerHeader">
             <FormattedMessage
               id={
-                values.publicationType === PUBLICATION_TYPES.DISSERTATION
+                isDissertation
                   ? 'common.contactDetails'
                   : 'form.isbnIsmn.preview.publisherDetails'
               }
             />
           </Typography>
-          {values.publicationType !== PUBLICATION_TYPES.DISSERTATION && (
+          {!isDissertation && (
             <>
               <ListComponent
                 label={<FormattedMessage id="form.common.name" />}
@@ -77,7 +79,7 @@ function Preview ({values, intl}) {
             label={<FormattedMessage id="form.common.city" />}
             value={values.city}
           />
-          {values.publicationType === PUBLICATION_TYPES.DISSERTATION && (
+          {isDissertation && (
             <ListComponent
               label={<FormattedMessage id="form.isbnIsmn.preview.universityName" />}
               value={<FormattedMessage id="form.isbnIsmn.preview.helsinki" />}
@@ -127,7 +129,7 @@ function Preview ({values, intl}) {
         </div>
 
         {/* Julkaisutoiminta - Publishing activities*/}
-        {values.publicationType !== PUBLICATION_TYPES.DISSERTATION && (
+        {!isDissertation && (
           <div className="listComponentContainer">
             <Typography variant="h3" className="listComponentContainerHeader">
               <FormattedMessage id="form.common.publishingActivities" />
@@ -229,7 +231,7 @@ function Preview ({values, intl}) {
         )}
 
         {/* Tekijät - Authors*/}
-        <div className="listComponentContainer listComponentAuthors">
+        <div className="listComponentContainer listComponentAuthors" data-isDissertation={isDissertation}>
           <Typography variant="h3" className="listComponentContainerHeader">
             <FormattedMessage id="form.isbnIsmn.preview.authors" />
           </Typography>

--- a/src/frontend/css/common.css
+++ b/src/frontend/css/common.css
@@ -18,6 +18,10 @@
   grid-column: 2 / 3;
 }
 
+.listComponentAuthors[data-isDissertation="true"] {
+  grid-row: 2/3;
+}
+
 .listComponentAdditionalDetails,
 .listComponentFormManagement,
 .listComponentOtherReference {
@@ -40,12 +44,12 @@
   padding: 0.6rem;
 }
 
-.listComponentContainerHeader {
+.listComponentContainer .listComponentContainerHeader {
   background-color: var(--color-brand-teal);
   color: var(--color-white);
   padding: 10px;
-  font-size: 1.25rem !important;
-  font-family: "Open Sans", Helvetica, sans-serif !important;
+  font-size: 1.25rem;
+  font-family: "Open Sans", Helvetica, sans-serif;
 }
 
 .buttons {
@@ -56,14 +60,6 @@
 
 .iconButton:active {
   transform: translateY(2px);
-}
-
-.titleTopSticky {
-  background: var(--color-brand-gray-20);
-  padding: 20px;
-  align-self: flex-start;
-  margin-top: 5px !important;
-  width: 100%;
 }
 
 .listItem {


### PR DESCRIPTION
Fixed an order of info boxes on the preview page of the dissertation form